### PR TITLE
docs(readme): add datetime directive to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ rtmp_auto_push directive.
                 hls on;
                 hls_path /tmp/app;
                 hls_fragment 5s;
+                hls_datetime system;
             }
 
         }


### PR DESCRIPTION
**Description**:
This adds a directive (`hls_datetime`) that enables segment tagging with `#EXT-X-PROGRAM-DATE-TIME`

See https://github.com/arut/nginx-rtmp-module/pull/379